### PR TITLE
combobox process item not deleted

### DIFF
--- a/App/MainForm.cs
+++ b/App/MainForm.cs
@@ -252,6 +252,9 @@ namespace App
 
         private void SetFFXIVProcess(Process process)
         {
+            //old process stack item not deleted cause active reloaded.
+			comboBox_Process.Items.Clear();
+			
             FFXIVProcess = process;
 
             var name = string.Format("{0}:{1}", FFXIVProcess.ProcessName, FFXIVProcess.Id);

--- a/App/MainForm.cs
+++ b/App/MainForm.cs
@@ -221,6 +221,7 @@ namespace App
 
         private void FindFFXIVProcess()
         {
+            comboBox_Process.Items.Clear();
             Log.I("파이널판타지14 프로세스를 찾는 중...");
 
             var processes = new List<Process>();


### PR DESCRIPTION
old process stack item not deleted cause active reloaded.
![bug_comboboxitem](https://cloud.githubusercontent.com/assets/20029869/16390578/74813766-3cde-11e6-8b21-a2a9def6fdd6.PNG)

이 상황은 FFXIV가 강제 종료된 후 프로세스가 메모리상/프로세스 목록에 남아있는 경우 발생.