### PR TITLE
3.2 이후 대응, 일부 작동 수정

### DIFF
--- a/App/Form/OverlayForm.Designer.cs
+++ b/App/Form/OverlayForm.Designer.cs
@@ -35,7 +35,7 @@
             // 
             // label_DutyCount
             // 
-            this.label_DutyCount.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.label_DutyCount.Font = new System.Drawing.Font("맑은 고딕", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.label_DutyCount.Location = new System.Drawing.Point(1, 3);
             this.label_DutyCount.Name = "label_DutyCount";
             this.label_DutyCount.Size = new System.Drawing.Size(245, 15);
@@ -46,10 +46,10 @@
             // label_DutyName
             // 
             this.label_DutyName.AutoEllipsis = true;
-            this.label_DutyName.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
-            this.label_DutyName.Location = new System.Drawing.Point(1, 22);
+            this.label_DutyName.Font = new System.Drawing.Font("맑은 고딕", 11.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.label_DutyName.Location = new System.Drawing.Point(1, 18);
             this.label_DutyName.Name = "label_DutyName";
-            this.label_DutyName.Size = new System.Drawing.Size(245, 15);
+            this.label_DutyName.Size = new System.Drawing.Size(245, 19);
             this.label_DutyName.TabIndex = 2;
             this.label_DutyName.Text = "<대미궁 바하무트: 진성편 4>";
             this.label_DutyName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;

--- a/App/Form/OverlayForm.Designer.cs
+++ b/App/Form/OverlayForm.Designer.cs
@@ -51,7 +51,7 @@
             this.label_DutyName.Name = "label_DutyName";
             this.label_DutyName.Size = new System.Drawing.Size(245, 19);
             this.label_DutyName.TabIndex = 2;
-            this.label_DutyName.Text = "<대미궁 바하무트: 진성편 4>";
+            this.label_DutyName.Text = "대미궁 바하무트: 진성편 4";
             this.label_DutyName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // label_DutyStatus

--- a/App/Form/OverlayForm.Designer.cs
+++ b/App/Form/OverlayForm.Designer.cs
@@ -46,7 +46,7 @@
             // label_DutyName
             // 
             this.label_DutyName.AutoEllipsis = true;
-            this.label_DutyName.Font = new System.Drawing.Font("맑은 고딕", 11.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.label_DutyName.Font = new System.Drawing.Font("맑은 고딕", 11.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.label_DutyName.Location = new System.Drawing.Point(1, 18);
             this.label_DutyName.Name = "label_DutyName";
             this.label_DutyName.Size = new System.Drawing.Size(245, 19);

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -41,6 +41,7 @@ namespace App
         int blinkCount;
         bool isOkay = false;
         bool isRoulette = false;
+        bool isMatched = false;
         internal int currentZone = 0;
         IntPtr m_eventHook;
 
@@ -160,6 +161,7 @@ namespace App
 
         internal void SetDutyStatus(Instance instance, byte tank, byte dps, byte healer)
         {
+            isMatched = false;
             this.Invoke(() =>
             {
                 if (!isRoulette)
@@ -183,6 +185,7 @@ namespace App
 
         internal void SetRoulleteDuty(Roulette roulette)
         {
+            isMatched = false;
             isRoulette = true;
             this.Invoke(() =>
             {
@@ -207,6 +210,8 @@ namespace App
 
         internal void SetConfirmStatus(Instance instance, byte tank, byte dps, byte healer)
         {
+            if (isMatched) return;
+
             this.Invoke(() =>
             {
                 label_DutyCount.Text = "입장 확인 중";
@@ -241,6 +246,7 @@ namespace App
 
         internal void CancelDutyFinderSync()
         {
+            isMatched = true;
             StopBlink();
 
             label_DutyCount.Text = "";

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -205,6 +205,22 @@ namespace App
             });
         }
 
+        internal void SetConfirmStatus(Instance instance, byte tank, byte dps, byte healer)
+        {
+            this.Invoke(() =>
+            {
+                label_DutyCount.Text = "입장 확인 중";
+                if (tank > instance.Tank || healer > instance.Healer || dps > instance.DPS) // 미리 구성된 파티?
+                {
+                    label_DutyStatus.Text = string.Format("{0}/{1}?", tank + healer + dps, instance.Tank + instance.Healer + instance.DPS);
+                }
+                else
+                {
+                    label_DutyStatus.Text = string.Format("{0}/{3}    {1}/{4}    {2}/{5}", tank, healer, dps, instance.Tank, instance.Healer, instance.DPS);
+                }
+            });
+        }
+
         internal void SetFATEAsAppeared(FATE fate)
         {
             this.Invoke(() =>

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -136,7 +136,7 @@ namespace App
                     m_overlay.BackColor = Color.FromArgb(64, 0, 0);
 
                     CancelDutyFinderSync();
-                    label_DutyName.Text = "< 클라이언트 통신 대기중... >";
+                    label_DutyName.Text = "클라이언트 통신 대기 중";
                 }
                 this.isOkay = isOkay;
             });
@@ -170,7 +170,7 @@ namespace App
             {
                 label_DutyCount.Text = "무작위 임무";
                 label_DutyName.Text = string.Format("< {0} >", roulette.Name);
-                label_DutyStatus.Text = string.Format("매칭 대기중");
+                label_DutyStatus.Text = string.Format("매칭 대기 중");
             });
         }
 
@@ -178,7 +178,7 @@ namespace App
         {
             this.Invoke(() =>
             {
-                label_DutyCount.Text = "입장 확인 대기중";
+                label_DutyCount.Text = "입장 확인 대기 중";
                 label_DutyName.Text = string.Format("< {0} >", instance.Name);
                 label_DutyStatus.Text = "매칭!";
 
@@ -210,7 +210,7 @@ namespace App
             StopBlink();
 
             label_DutyCount.Text = "";
-            label_DutyName.Text = "< 매칭중인 임무 없음 >";
+            label_DutyName.Text = "매칭 중인 임무 없음";
             label_DutyStatus.Text = "";
         }
 

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -169,7 +169,7 @@ namespace App
                 }
                 else
                 {
-                    if (tank == 0 || tank == 255) // 0: 순번 지원되지 않음, 255: 순번 대기
+                    if (tank == 255) // 순번 대기
                     {
                         label_DutyStatus.Text = "매칭 대기 중";
                     }

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -188,7 +188,7 @@ namespace App
             {
                 label_DutyCount.Text = "무작위 임무";
                 label_DutyName.Text = string.Format("< {0} >", roulette.Name);
-                label_DutyStatus.Text = string.Format("매칭 대기 중");
+                label_DutyStatus.Text = "매칭 대기 중";
             });
         }
 

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -147,20 +147,38 @@ namespace App
             isRoulette = false;
             this.Invoke(() =>
             {
-                label_DutyCount.Text = string.Format("총 {0}개 임무 매칭중", dutyCount);
+                if(dutyCount < 0)
+                {
+                    label_DutyCount.Text = "임무 매칭 중";
+                }
+                else
+                {
+                    label_DutyCount.Text = string.Format("총 {0}개 임무 매칭 중", dutyCount);
+                }
             });
         }
 
         internal void SetDutyStatus(Instance instance, byte tank, byte dps, byte healer)
         {
-            if (!isRoulette)
+            this.Invoke(() =>
             {
-                this.Invoke(() =>
+                if (!isRoulette)
                 {
                     label_DutyName.Text = string.Format("< {0} >", instance.Name);
                     label_DutyStatus.Text = string.Format("{0}/{3}    {1}/{4}    {2}/{5}", tank, healer, dps, instance.Tank, instance.Healer, instance.DPS);
-                });
-            }
+                }
+                else
+                {
+                    if (tank == 0 || tank == 255) // 0: 순번 지원되지 않음, 255: 순번 대기
+                    {
+                        label_DutyStatus.Text = "매칭 대기 중";
+                    }
+                    else // TODO: 순번이 1번일 때?
+                    {
+                        label_DutyStatus.Text = string.Format("대기 순번: {0}", tank + 1);
+                    }
+                }
+            });
         }
 
         internal void SetRoulleteDuty(Roulette roulette)

--- a/App/Form/OverlayForm.cs
+++ b/App/Form/OverlayForm.cs
@@ -164,7 +164,7 @@ namespace App
             {
                 if (!isRoulette)
                 {
-                    label_DutyName.Text = string.Format("< {0} >", instance.Name);
+                    label_DutyName.Text = instance.Name;
                     label_DutyStatus.Text = string.Format("{0}/{3}    {1}/{4}    {2}/{5}", tank, healer, dps, instance.Tank, instance.Healer, instance.DPS);
                 }
                 else
@@ -187,7 +187,7 @@ namespace App
             this.Invoke(() =>
             {
                 label_DutyCount.Text = "무작위 임무";
-                label_DutyName.Text = string.Format("< {0} >", roulette.Name);
+                label_DutyName.Text = roulette.Name;
                 label_DutyStatus.Text = "매칭 대기 중";
             });
         }
@@ -197,7 +197,7 @@ namespace App
             this.Invoke(() =>
             {
                 label_DutyCount.Text = "입장 확인 대기 중";
-                label_DutyName.Text = string.Format("< {0} >", instance.Name);
+                label_DutyName.Text = instance.Name;
                 label_DutyStatus.Text = "매칭!";
 
                 accentColor = Color.Red;
@@ -226,7 +226,7 @@ namespace App
             this.Invoke(() =>
             {
                 label_DutyCount.Text = Data.GetArea(fate.Zone).Name;
-                label_DutyName.Text = string.Format("< {0} >", fate.Name);
+                label_DutyName.Text = fate.Name;
                 label_DutyStatus.Text = "돌발 임무 발생!";
 
                 accentColor = Color.DarkOrange;

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -263,8 +263,7 @@ namespace App
                 }
                 else if (opcode == 0x0076)
                 {
-                    var code = data[184];
-
+                    var code = data[192];
                     var roulette = Data.GetRoulette(code);
 
                     state = State.QUEUED;

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -166,7 +166,7 @@ namespace App
 
                             if (teleMeasure != 0x0C)
                             {
-                                Log.D("{1}{2} 지역을 이동했습니다. ({0})", code, Data.GetAreaName(code), lastChar);
+                                Log.D("{1}{2} 지역으로 이동했습니다. ({0})", code, Data.GetAreaName(code), lastChar);
                             }
                             else
                             {

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -348,6 +348,8 @@ namespace App
                     else if (status == 4)
                     {
                         // 매칭 뒤 참가자 확인 현황 패킷
+                        // TODO: 조율 해제 파티의 최대 인원 수 정확히 알아내기
+                        mainForm.overlayForm.SetConfirmStatus(instance, tank, dps, healer);
                     }
 
                     Log.I("DFAN: 매칭 상태 업데이트됨 [{0}, {1}, {2}/{3}, {4}/{5}, {6}/{7}]",

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -273,7 +273,7 @@ namespace App
                 }
                 else if (opcode == 0x02DB)
                 {
-                    var status = data[4];
+                    var status = data[0];
 
                     if (status == 3)
                     {

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -335,7 +335,7 @@ namespace App
                         {
                             // 프로그램이 매칭 중간에 켜짐
                             state = State.QUEUED;
-                            mainForm.overlayForm.SetDutyCount(1); // 임의로 1개로 설정함 (TODO: 알아낼 방법 있으면 정학히 나오게 수정하기)
+                            mainForm.overlayForm.SetDutyCount(-1); // 알 수 없음으로 설정함 (TODO: 알아낼 방법 있으면 정확히 나오게 수정하기)
                             mainForm.overlayForm.SetDutyStatus(instance, tank, dps, healer);
                         }
                         else if (state == State.QUEUED)


### PR DESCRIPTION
패킷 대응:
* 0x0076 (무작위 임무 매칭 시작) 때 임무 코드가 184에서 192로 옮겨감
* 0x02DB (매칭 중단/완료) 때 status 인덱스가 4에서 0으로 옮겨감

변경점:
* 매칭이 여러 개 돌아가고 있는데 몇 개인지 모를 때 그냥 "임무 매칭 중"이라고만 표시합니다.
* 무작위 매칭 시 큐의 현재 순번을 보여줍니다.
  * 인게임 순번보다 업데이트가 빠른...데 데이터가 틀리진 않음
  * 큐가 없는 `무작위 임무: 전장`은 이전처럼 표시됩니다.
* `< {0} >` -> `{0}`
* 입장 확인 현황 표시 ㅡ 조율 해제 파티는 반쯤 신경쓰지 않기로

기타:
* `Network.Analyze.cs`만 CRLF가 아닌 것 같습니다
