### PR TITLE
글로벌 서버 무작위 임무 지원

### DIFF
--- a/App/Data.cs
+++ b/App/Data.cs
@@ -13,6 +13,7 @@ namespace App
         public static Dictionary<int, Area> Areas { get; set; }
         public static Dictionary<int, FATE> FATEs { get; set; }
         public static Dictionary<int, Roulette> Roulettes { get; set; }
+        public static Dictionary<int, Roulette> RoulettesGS { get; set; }
 
         public static void Initializer()
         {
@@ -35,6 +36,7 @@ namespace App
                     var areas = new Dictionary<int, Area>();
                     var fates = new Dictionary<int, FATE>();
                     var roulettes = new Dictionary<int, Roulette>();
+                    var roulettesGS = new Dictionary<int, Roulette>();
 
                     foreach (XmlNode xn in doc.SelectNodes("/Data/Item"))
                     {
@@ -57,9 +59,18 @@ namespace App
                         roulettes.Add(id, new Roulette(name));
                     }
 
+                    foreach (XmlNode xn in doc.SelectNodes("/Data/RouletteGS"))
+                    {
+                        var id = int.Parse(xn.FindAttribute("Id"), System.Globalization.NumberStyles.HexNumber);
+                        var name = xn.FindAttribute("Text");
+
+                        roulettesGS.Add(id, new Roulette(name));
+                    }
+
                     Areas = areas;
                     FATEs = fates;
                     Roulettes = roulettes;
+                    RoulettesGS = roulettesGS;
                     Version = version;
 
                     if (Initialized)
@@ -194,13 +205,17 @@ namespace App
         internal static List<KeyValuePair<int, FATE>> GetFATEs()
         {
             return FATEs.ToList();
-        }
+        }   
 
-        internal static Roulette GetRoulette(int code)
+        internal static Roulette GetRoulette(int code, Boolean isGlobal)
         {
-            if (Roulettes.ContainsKey(code))
+            if (Roulettes.ContainsKey(code) && isGlobal == false)
             {
                 return Roulettes[code];
+            }
+            else if (RoulettesGS.ContainsKey(code) && isGlobal == true)
+            {
+                return RoulettesGS[code];
             }
 
             if (code != 0)

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -133,7 +133,8 @@ namespace App
 
                 var opcode = BitConverter.ToUInt16(message, 18);
 
-                if (opcode != 0x0074 &&
+                if (opcode != 0x00B0 &&
+                    opcode != 0x0074 &&
                     opcode != 0x0076 &&
                     opcode != 0x0078 &&
                     opcode != 0x0079 &&
@@ -266,6 +267,16 @@ namespace App
                     mainForm.overlayForm.SetDutyCount(instances.Count);
 
                     Log.I("DFAN: 매칭 시작됨 (74) [{0}]", string.Join(", ", instances.Select(x => x.Name).ToArray()));
+                }
+                else if (opcode == 0x00B0) //글로벌 서버 무작위 임무
+                {
+                    var code = data[4];
+                    var roulette = Data.GetRoulette(code);
+
+                    state = State.QUEUED;
+                    mainForm.overlayForm.SetRoulleteDuty(roulette);
+
+                    Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
                 }
                 else if (opcode == 0x0076)
                 {

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -278,10 +278,10 @@ namespace App
 
                     Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
                 }
-                else if (opcode == 0x00B0) //글로벌 서버 무작위 임무
+                else if (opcode == 0x00B0 && data.Length == 8) //글로벌 서버 무작위 임무, 한국서버에서도 opcode 0x00B0이 쓰이지만 data 배열 길이가 다름을 이용하여 서버를 구분함.
                 {
                     var code = data[4];
-                    var roulette = Data.GetRoulette(code);
+                    var roulette = Data.GetRoulette(code, true);
 
                     state = State.QUEUED;
                     mainForm.overlayForm.SetRoulleteDuty(roulette);

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -271,13 +271,13 @@ namespace App
                 else if (opcode == 0x0076)
                 {
                     var code = data[192];
-                    var roulette = Data.GetRoulette(code);
+                    var roulette = Data.GetRoulette(code, false);
 
                     state = State.QUEUED;
                     mainForm.overlayForm.SetRoulleteDuty(roulette);
 
                     Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
-                }
+                }   
                 else if (opcode == 0x00B0 && data.Length == 8) //글로벌 서버 무작위 임무, 한국서버에서도 opcode 0x00B0이 쓰이지만 data 배열 길이가 다름을 이용하여 서버를 구분함.
                 {
                     var code = data[4];

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -133,14 +133,14 @@ namespace App
 
                 var opcode = BitConverter.ToUInt16(message, 18);
 
-                if (opcode != 0x00B0 &&
-                    opcode != 0x0074 &&
+                if (opcode != 0x0074 &&
                     opcode != 0x0076 &&
                     opcode != 0x0078 &&
                     opcode != 0x0079 &&
                     opcode != 0x0080 &&
                     opcode != 0x006C &&
                     opcode != 0x006F &&
+                    opcode != 0x00B0 &&
                     opcode != 0x0142 &&
                     opcode != 0x0143)
                     return;
@@ -267,17 +267,7 @@ namespace App
                     mainForm.overlayForm.SetDutyCount(instances.Count);
 
                     Log.I("DFAN: 매칭 시작됨 (74) [{0}]", string.Join(", ", instances.Select(x => x.Name).ToArray()));
-                }
-                else if (opcode == 0x00B0) //글로벌 서버 무작위 임무
-                {
-                    var code = data[4];
-                    var roulette = Data.GetRoulette(code);
-
-                    state = State.QUEUED;
-                    mainForm.overlayForm.SetRoulleteDuty(roulette);
-
-                    Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
-                }
+                }              
                 else if (opcode == 0x0076)
                 {
                     var code = data[192];
@@ -288,6 +278,16 @@ namespace App
 
                     Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
                 }
+                else if (opcode == 0x00B0) //글로벌 서버 무작위 임무
+                {
+                    var code = data[4];
+                    var roulette = Data.GetRoulette(code);
+
+                    state = State.QUEUED;
+                    mainForm.overlayForm.SetRoulleteDuty(roulette);
+
+                    Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
+                }   
                 else if (opcode == 0x0078)
                 {
                     var status = data[0];

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -267,7 +267,7 @@ namespace App
                     mainForm.overlayForm.SetDutyCount(instances.Count);
 
                     Log.I("DFAN: 매칭 시작됨 (74) [{0}]", string.Join(", ", instances.Select(x => x.Name).ToArray()));
-                }              
+                }
                 else if (opcode == 0x0076)
                 {
                     var code = data[192];

--- a/App/Resources/ZoneList.xml
+++ b/App/Resources/ZoneList.xml
@@ -1336,18 +1336,18 @@
     </Item>
 
     <!-- 4.01 레이드 -->
-    <Item ZoneId="2B3" Text="Atherial Rift" Duty="차원의 틈새 오메가 델타편 1">
+    <Item ZoneId="2B3" Text="Atherial Rift" Duty="차원의 틈새 오메가: 델타편 1">
       <Duty Tank="2" Healer="2" DPS="4" />
     </Item>
-    <Item ZoneId="2B4" Text="Atherial Rift" Duty="차원의 틈새 오메가 델타편 2">
+    <Item ZoneId="2B4" Text="Atherial Rift" Duty="차원의 틈새 오메가: 델타편 2">
       <Duty Tank="2" Healer="2" DPS="4" />
     </Item>
-    <Item ZoneId="2B5" Text="Atherial Rift" Duty="차원의 틈새 오메가 델타편 3">
+    <Item ZoneId="2B5" Text="Atherial Rift" Duty="차원의 틈새 오메가: 델타편 3">
       <Duty Tank="2" Healer="2" DPS="4" />
     </Item>
-    <Item ZoneId="2B6" Text="Atherial Rift" Duty="차원의 틈새 오메가 델타편 4">
+    <Item ZoneId="2B6" Text="Atherial Rift" Duty="차원의 틈새 오메가: 델타편 4">
       <Duty Tank="2" Healer="2" DPS="4" />
-    </Item>
+    </Item> 
    
     <!-- 길드 작전 -->
     <Item ZoneId="BE" Text="검은장막 숲 중부삼림" Duty="방황하는 사령을 쓰러뜨려라!">

--- a/App/Resources/ZoneList.xml
+++ b/App/Resources/ZoneList.xml
@@ -1,5 +1,5 @@
 ﻿<Data>
-    <Version>20170706.1</Version>
+    <Version>20170708.1</Version>
 
     <!-- 무작위 임무 -->
     <Roulette Id="1" Text="무작위 임무: 레벨링" />

--- a/App/Resources/ZoneList.xml
+++ b/App/Resources/ZoneList.xml
@@ -3,7 +3,7 @@
 
     <!-- 무작위 임무 -->
     <Roulette Id="1" Text="무작위 임무: 레벨링" />
-    <Roulette Id="2" Text="무작위 임무: 레벨 50 던전" />
+    <Roulette Id="2" Text="무작위 임무: 레벨 50 던전" />
     <Roulette Id="3" Text="무작위 임무: 주요 퀘스트" />
     <Roulette Id="4" Text="무작위 임무: 길드 작전" />
     <Roulette Id="5" Text="무작위 임무: 숙련자" />
@@ -11,6 +11,17 @@
     <Roulette Id="7" Text="무작위 임무: 전장" />
     <Roulette Id="8" Text="무작위 임무: 레벨 60 던전" />
     <Roulette Id="9" Text="무작위 임무: 멘토" />
+
+    <!-- 무작위 임무 (글로벌 서버용) -->
+    <RouletteGS Id="1" Text="무작위 임무: 레벨링" />
+    <RouletteGS Id="2" Text="무작위 임무: 레벨 50/60 던전" />
+    <RouletteGS Id="3" Text="무작위 임무: 주요 퀘스트" />
+    <RouletteGS Id="4" Text="무작위 임무: 길드 작전" />
+    <RouletteGS Id="5" Text="무작위 임무: 숙련자" />
+    <RouletteGS Id="6" Text="무작위 임무: 토벌전" />
+    <RouletteGS Id="7" Text="무작위 임무: 전장" />
+    <RouletteGS Id="8" Text="무작위 임무: 레벨 70 던전" />
+    <RouletteGS Id="9" Text="무작위 임무: 멘토" />
   
     <!-- 2.x 신생 에오르제아 -->
     <Item ZoneId="80" Text="림사 로민사 상층 갑판" Rest="1" />


### PR DESCRIPTION
글로벌 서버에서 무작위 임무 신청시 나오는 opcode가 0x00B0 으로 확인되었습니다.
임무 정보는 data[4]에 나타나며, 3.x에서 사용하던 id를 그대로 사용할 수 있습니다. (xml파일에 적용된 id를 말함)
다만, 글로벌 서버에서, 무작위 50레벨 던전이 아니라 무작위 50/60 던전으로 바뀌었는데, 이 부분은 아직 납뒀습니다. (Xml파일에는 한국 서버를 기준으로 하여, 50던전으로 저장되어 있기 때문에 50던전으로 출력되고 있습니다.)
(대충 Xml파일의 Roulette부분을 한국 서버 전용으로 하고 RouletteGS를 새로 만들어서 글로벌 서버용 데이터를 넣은 후에, 글로벌 서버 무작위 던전을 신청했을 때는 RouletteGS를 참고하는 식으로 바꾸면 될 것 같습니다.)
특별한 문제가 있는건 아니지만, 아직 소스 이해도가 부족해 고치지 못했습니다.

* opcode == 0x00B0이 한국 서버에서 어떻게 쓰이고 있는지 확인하지 못했습니다. 다만, 5분간 이것저것 해본 결과 충돌이 감지되지 않았습니다. 앞으로도 프로그램 사용하며 문제 발생하면 글로벌 서버 선택 또는 감지 옵션을 추가하도록 하겠습니다.

+ 사소한 던전 명칭 개선이 있습니다.