### PR TITLE
글로벌 서버 몇몇 문제 해결 / 코드 최적화

### DIFF
--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -367,7 +367,7 @@ namespace App
                     if (status == 128)
                     {
                         // 매칭 참가 신청 확인 창에서 확인을 누름
-                        mainForm.overlayForm.StopBlink()
+                        mainForm.overlayForm.StopBlink();       
                     }
                 }
                 else if (opcode == 0x0079)

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -280,9 +280,10 @@ namespace App
 
                     Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
                 }   
-                else if (opcode == 0x00B0 && data.Length == 8)
+                else if (opcode == 0x00B0 && data.Length == 8 && data[4] != 0)
                 {
                     //글로벌 서버 무작위 임무, 한국서버에서도 opcode 0x00B0이 쓰이지만 data 배열 길이가 다름을 이용하여 서버를 구분함.
+                    //글로벌 서버에서 특정 임무 신청시, opcode = 0x00B0, data[4] = 0 이 출력됨.           
 
                     var code = data[4];
                     var roulette = Data.GetRoulette(code, true);

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -141,6 +141,7 @@ namespace App
                     opcode != 0x006C &&
                     opcode != 0x006F &&
                     opcode != 0x00B0 &&
+                    opcode != 0x0121 &&     
                     opcode != 0x0142 &&
                     opcode != 0x0143)
                     return;
@@ -370,6 +371,16 @@ namespace App
                         // 플레이어가 매칭 참가 확인 창에서 확인을 누름
                         // 다른 매칭 인원들도 전부 확인을 눌렀을 경우 입장을 위해 상단 2DB status 6 패킷이 옴
                         mainForm.overlayForm.StopBlink();
+                    }
+                }
+                else if (opcode == 0x0121) //글로벌 서버
+                {
+                    var status = data[5];
+
+                    if (status == 128)
+                    {
+                        // 매칭 참가 신청 확인 창에서 확인을 누름
+                        mainForm.overlayForm.StopBlink()
                     }
                 }
                 else if (opcode == 0x0079)


### PR DESCRIPTION
예상치 못한 곳에서 문제가 생겨서 이제서야 고쳤습니다.
글로벌 서버 특정 임무 신청시에도 충돌이 발생하네요.
특정 임무 신청시에는 data[4] (무작위 임무 id가 보내지는 부분)에 0이 나온다는 점을 이용해서 특정 임무 신청임을 구분하였습니다.

- 주고 받는 패킷 전부를 확인하고 구분을 하는게 아니라 이 부분을 이용하면 구분할 수 있겠다라는 생각으로 문제 발생시마다 하나하나 조건을 달고 있어서 if문 조건이 늘어지고 있는데... 한꺼번에 구분하는 방식으로 if문 조건을 더 줄일 수 있는 방법이 있을지도 모릅니다.