### PR TITLE
글로벌 서버 몇몇 문제 해결 / 코드 최적화

### DIFF
--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -133,14 +133,12 @@ namespace App
 
                 var opcode = BitConverter.ToUInt16(message, 18);
 
-                if (opcode != 0x0074 &&
-                    opcode != 0x0076 &&
+                if (opcode != 0x0074 && 
                     opcode != 0x0078 &&
                     opcode != 0x0079 &&
                     opcode != 0x0080 &&
                     opcode != 0x006C &&
                     opcode != 0x006F &&
-                    opcode != 0x00B0 &&
                     opcode != 0x0121 &&     
                     opcode != 0x0142 &&
                     opcode != 0x0143)

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -367,7 +367,7 @@ namespace App
                     if (status == 128)
                     {
                         // 매칭 참가 신청 확인 창에서 확인을 누름
-                        mainForm.overlayForm.StopBlink()
+                        mainForm.overlayForm.StopBlink();       
                     }
                 }
                 else if (opcode == 0x0079)

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -280,9 +280,10 @@ namespace App
 
                     Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
                 }   
-                else if (opcode == 0x00B0 && data.Length == 8)
+                else if (opcode == 0x00B0 && data.Length == 8 && data[4] != 0)
                 {
                     //글로벌 서버 무작위 임무, 한국서버에서도 opcode 0x00B0이 쓰이지만 data 배열 길이가 다름을 이용하여 서버를 구분함.
+                    //글로벌 서버에서 특정 임무 신청시, opcode = 0x00B0, data[4] = 0 이 출력됨.           
 
                     var code = data[4];
                     var roulette = Data.GetRoulette(code, true);

--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -141,6 +141,7 @@ namespace App
                     opcode != 0x006C &&
                     opcode != 0x006F &&
                     opcode != 0x00B0 &&
+                    opcode != 0x0121 &&     
                     opcode != 0x0142 &&
                     opcode != 0x0143)
                     return;
@@ -370,6 +371,16 @@ namespace App
                         // 플레이어가 매칭 참가 확인 창에서 확인을 누름
                         // 다른 매칭 인원들도 전부 확인을 눌렀을 경우 입장을 위해 상단 2DB status 6 패킷이 옴
                         mainForm.overlayForm.StopBlink();
+                    }
+                }
+                else if (opcode == 0x0121) //글로벌 서버
+                {
+                    var status = data[5];
+
+                    if (status == 128)
+                    {
+                        // 매칭 참가 신청 확인 창에서 확인을 누름
+                        mainForm.overlayForm.StopBlink()
                     }
                 }
                 else if (opcode == 0x0079)


### PR DESCRIPTION
임무 신청 판별법을 개선하였습니다. (코드 최적화)
동시에 글로벌 서버에서 특정 임무 신청과 무작위 임무 신청을 구분하지 못하던 문제가 해결되었습니다.
글로벌 서버에서 입장 확인 버튼을 누르면, 오버레이가 깜빡깜빡 거리던 것을 멈추게 하였습니다.

타인이 취소를 누르는 경우에, 오버레이가 깜빡이는 것을 멈추도록 하는 부분은 확인하지 못했습니다. (테스트가 필요한데 타인이 취소를 누르는 경우가 너무 적어서 제대로 테스트하지 못함)
본인이 취소를 누르는 경우도 테스트를 제대로 하지 못했는데... 매칭이 잡히고 취소를 하는 행위를 하루 3번 이상하면 그 이후로 취소를 할 경우, 매칭이 30분간 제한됩니다.. 그래서 테스트가 늦어지고 있습니다. (인원수 제한 해제하고 매칭 테스트를 해보는건 아직 하지 않았습니다.)