### PR TITLE
Network Analyser Patch

### DIFF
--- a/App/Network/Network.Analyser.cs
+++ b/App/Network/Network.Analyser.cs
@@ -134,14 +134,12 @@ namespace App
 
                 var opcode = BitConverter.ToUInt16(message, 18);
 
-                if (opcode != 0x0074 &&
-                    opcode != 0x0076 &&
-                    opcode != 0x0078 &&
+                if (opcode != 0x0078 &&
                     opcode != 0x0079 &&
                     opcode != 0x0080 &&
                     opcode != 0x006C &&
                     opcode != 0x006F &&
-                    opcode != 0x00B0 &&
+                    opcode != 0x0121 &&
                     opcode != 0x0142 &&
                     opcode != 0x0143)
                     return;
@@ -244,60 +242,49 @@ namespace App
 
                     Log.I("DFAN: 매칭 시작됨 (6C) [{0}]", instance.Name);
                 }
-                else if (opcode == 0x0074)
-                {
-                    var instances = new List<Instance>();
-
-                    for (var i = 0; i < 5; i++)
-                    {
-                        var code = BitConverter.ToUInt16(data, 194 + i * 2);
-                        if (code == 0)
-                        {
-                            break;
-                        }
-                        instances.Add(Data.GetInstance(code));
-                    }
-
-                    if (!instances.Any())
-                    {
-                        return;
-                    }
-
-                    state = State.QUEUED;
-                    mainForm.overlayForm.SetDutyCount(instances.Count);
-
-                    Log.I("DFAN: 매칭 시작됨 (74) [{0}]", string.Join(", ", instances.Select(x => x.Name).ToArray()));
-                }
-                else if (opcode == 0x0076)
-                {
-                    // 한국 서버 무작위 임무
-
-                    var code = data[192];
-                    var roulette = Data.GetRoulette(code);
-
-                    state = State.QUEUED;
-                    mainForm.overlayForm.SetRoulleteDuty(roulette);
-
-                    Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
-                }   
-                else if (opcode == 0x00B0 && data.Length == 8)
-                {
-                    //글로벌 서버 무작위 임무, 한국서버에서도 opcode 0x00B0이 쓰이지만 data 배열 길이가 다름을 이용하여 서버를 구분함.
-
-                    var code = data[4];
-                    var roulette = Data.GetRoulette(code);
-
-                    state = State.QUEUED;
-                    mainForm.overlayForm.SetRoulleteDuty(roulette);
-
-                    Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
-                }   
                 else if (opcode == 0x0078)
                 {
                     var status = data[0];
                     var reason = data[4];
-                 
-                    if (status == 3)
+
+                    if (status == 0)
+                    {
+                        state = State.QUEUED;
+
+                        var rouletteCode = data[20];
+
+                        if (rouletteCode != 0 && (data[15] == 0 || data[15] == 64)) //무작위 임무 신청, 한국서버/글로벌 서버
+                        {
+                            var roulette = Data.GetRoulette(rouletteCode);
+                            mainForm.overlayForm.SetRoulleteDuty(roulette);
+                            Log.I("DFAN: 무작위 임무 매칭 시작됨 [{0}]", roulette.Name);
+                        }
+
+                        else //특정 임무 신청
+                        {
+                            var instances = new List<Instance>();
+
+                            for (int i = 0; i < 5; i++)
+                            {
+                                var code = BitConverter.ToUInt16(data, 22 + (i * 2));
+                                if (code == 0)
+                                {
+                                    break;
+                                }
+                                instances.Add(Data.GetInstance(code));
+                            }
+
+                            if (!instances.Any())
+                            {
+                                return;
+                            }
+
+                            mainForm.overlayForm.SetDutyCount(instances.Count);
+
+                            Log.I("DFAN: 매칭 시작됨 (78) [{0}]", string.Join(", ", instances.Select(x => x.Name).ToArray()));
+                        }
+                    }
+                    else if (status == 3)
                     {
                         state = reason == 8 ? State.QUEUED : State.IDLE;
                         mainForm.overlayForm.CancelDutyFinder();
@@ -310,6 +297,42 @@ namespace App
                         mainForm.overlayForm.CancelDutyFinder();
 
                         Log.I("DFAN: 입장함");
+                    }
+                    else if (status == 4) //글섭에서 매칭 잡혔을 때 출력
+                    {
+                        var roulette = data[20];
+                        var code = BitConverter.ToUInt16(data, 22);
+
+                        Instance instance;
+
+                        if (!Settings.CheatRoulette && roulette != 0)
+                        {
+                            instance = new Instance { Name = Data.GetRoulette(roulette).Name };
+                        }
+                        else
+                        {
+                            instance = Data.GetInstance(code);
+                        }
+
+                        state = State.MATCHED;
+                        mainForm.overlayForm.SetDutyAsMatched(instance);
+
+                        if (Settings.FlashWindow)
+                        {
+                            WinApi.FlashWindow(mainForm.FFXIVProcess);
+                        }
+
+                        if (!Settings.ShowOverlay)
+                        {
+                            mainForm.ShowNotification("< {0} > 매칭!", instance.Name);
+                        }
+
+                        if (Settings.TwitterEnabled)
+                        {
+                            WebApi.Tweet("< {0} > 매칭!", instance.Name);
+                        }
+
+                        Log.S("DFAN: 매칭됨 [{0}]", instance.Name);
                     }
                 }
                 else if (opcode == 0x006F)
@@ -325,6 +348,16 @@ namespace App
                     {
                         // 플레이어가 매칭 참가 확인 창에서 확인을 누름
                         // 다른 매칭 인원들도 전부 확인을 눌렀을 경우 입장을 위해 상단 2DB status 6 패킷이 옴
+                        mainForm.overlayForm.StopBlink();
+                    }
+                }
+                else if (opcode == 0x0121) //글로벌 서버
+                {
+                    var status = data[5];
+
+                    if (status == 128)
+                    {
+                        // 매칭 참가 신청 확인 창에서 확인을 누름
                         mainForm.overlayForm.StopBlink();
                     }
                 }


### PR DESCRIPTION
**글로벌 서버 지원 개선**
1. 매칭 확인 버튼 클릭 후, 오버레이 깜빡임을 멈춤
2. 매칭 신청시 오버레이에 띄워주는 정보 개선 (매칭 신청 직후, 현재 매칭 중인 임무의 갯수를 보여줌.)

**한국 서버, 글로벌 서버 매칭 신청 확인하는 과정 통합**

**아직 존재하는 문제점**
글로벌 서버에서 매칭을 취소한 것이 아님에도 로그에 매칭 취소 로그가 나옴. 프로그램을 사용하는데는 문제가 없음.

**확인하지 못한 문제들** (글로벌 서버만 해당)
매칭 완료 후, 입장 전에 타인이 취소를 누르는 경우를 확인하지 못함. 프로그램에서 처리하지 못하고 있다면, 1. 오버레이 깜빡임 멈춤 필요. 2. 오버레이 매칭 대기 화면으로 넘어가야 함.

지금까지 사용해본 결과로는 한국서버 이용에는 문제가 없음.